### PR TITLE
New time reporter added

### DIFF
--- a/Shtirlitz.Library/Reporter/TimeReporter/CurrentTimeProvider.cs
+++ b/Shtirlitz.Library/Reporter/TimeReporter/CurrentTimeProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Shtirlitz.Reporter
+{
+    public class CurrentTimeProvider : ITimeProvider
+    {
+        public DateTimeOffset GetTime()
+        {
+            return DateTimeOffset.Now;
+        }
+    }
+}

--- a/Shtirlitz.Library/Reporter/TimeReporter/ITimeProvider.cs
+++ b/Shtirlitz.Library/Reporter/TimeReporter/ITimeProvider.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Shtirlitz.Reporter
+{
+    public interface ITimeProvider
+    {
+        DateTimeOffset GetTime();
+    }
+}

--- a/Shtirlitz.Library/Reporter/TimeReporter/TimeReporter.cs
+++ b/Shtirlitz.Library/Reporter/TimeReporter/TimeReporter.cs
@@ -1,0 +1,64 @@
+﻿using Shtirlitz.Common;
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Shtirlitz.Reporter
+{
+    /// <summary>
+    /// Report time
+    /// </summary>
+    public class TimeReporter : IReporter
+    {
+        ITimeProvider _timeProvider;
+
+        #region Constructors
+        public TimeReporter()
+            : this(new CurrentTimeProvider())
+        {
+        }
+
+        public TimeReporter(ITimeProvider timeProvider)
+        {
+            if (timeProvider == null)
+                throw new ArgumentNullException("timeProvider");
+
+            _timeProvider = timeProvider;
+        }
+        #endregion
+
+        public double Weight
+        {
+            get { return 1d; }
+        }
+
+        public string Name
+        {
+            get { return "Gets system time"; }
+        }
+
+        public void Report(string rootPath, CancellationToken cancellationToken, SimpleProgressCallback progressCallback = null)
+        {
+            // get a file name for the report
+            string filename = Path.Combine(rootPath, GetFileNameFromTime(_timeProvider.GetTime()));
+
+            // create report file
+            try
+            {
+                File.CreateText(filename).Close();
+            }
+            catch (IOException ex)
+            {
+                throw new IOException(string.Format("Failed to create report file \"{0}\". See the inner exceptions for details", filename), ex);
+            }
+
+            // report progress
+            progressCallback.TryInvoke(1d);
+        }
+
+        public string GetFileNameFromTime(DateTimeOffset time)
+        {
+            return string.Format("{0}.txt", time).Replace(":", ".");
+        }
+    }
+}

--- a/Shtirlitz.Library/Shtirlitz.Library.csproj
+++ b/Shtirlitz.Library/Shtirlitz.Library.csproj
@@ -43,6 +43,9 @@
   <ItemGroup>
     <Compile Include="Archiver\DotNetZipArchiver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Reporter\TimeReporter\CurrentTimeProvider.cs" />
+    <Compile Include="Reporter\TimeReporter\ITimeProvider.cs" />
+    <Compile Include="Reporter\TimeReporter\TimeReporter.cs" />
     <Compile Include="Reporter\WmiDumper.cs" />
     <Compile Include="Sender\ArchiveRemover.cs" />
     <Compile Include="Sender\ClipboardCopier.cs" />

--- a/Shtirlitz.Tests/Shtirlitz.Tests.csproj
+++ b/Shtirlitz.Tests/Shtirlitz.Tests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="ShtirlitzBaseTestClass.cs" />
     <Compile Include="ShtirlitzTests.cs" />
     <Compile Include="StageRunnerTests.cs" />
+    <Compile Include="TimeReporterTests.cs" />
     <Compile Include="WmiDumperTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Shtirlitz.Tests/TimeReporterTests.cs
+++ b/Shtirlitz.Tests/TimeReporterTests.cs
@@ -1,0 +1,52 @@
+﻿using Shtirlitz.Reporter;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace Shtirlitz.Tests
+{
+    public class TimeReporterTests : ShtirlitzBaseTestClass
+    {
+        private readonly TimeReporter _reporter;
+        private static DateTimeOffset _customTime = new DateTime(2014, 1, 15, 0, 0, 0);
+
+        #region Constructors
+        public TimeReporterTests()
+            : this(new TimeReporter(new TestTimeProvider(_customTime)))
+        {
+        }
+
+        public TimeReporterTests(TimeReporter reporter)
+            : base(new List<IReporter> { reporter })
+        {
+            _reporter = reporter;
+        }
+        #endregion
+
+        [Fact]
+        public void TimeReporter_ReportTest()
+        {
+            // act
+            RunSynchronously(false);
+
+            // assert
+            Assert.True(File.Exists(Path.Combine(RootPath, _reporter.GetFileNameFromTime(_customTime))));
+        }
+
+        class TestTimeProvider : ITimeProvider
+        {
+            DateTimeOffset _time;
+
+            public TestTimeProvider(DateTimeOffset time)
+            {
+                _time = time;
+            }
+
+            public DateTimeOffset GetTime()
+            {
+                return _time;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Seems that all notices ware corrected.

PS: DateTimeOffset was used because of: "the name should also contain a UTC offset"
PPS: marked local variables as private explicitly, but they are implicitly private by default...
